### PR TITLE
Add Student Groups Webpage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nusc-website-frontend-test",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.5",
         "@radix-ui/react-navigation-menu": "^1.2.4",
         "@radix-ui/react-slot": "^1.1.1",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -881,6 +883,186 @@
       "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
+      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.1.tgz",
@@ -1231,6 +1413,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
@@ -1268,6 +1483,39 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
       "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1329,6 +1577,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.5",
     "@radix-ui/react-navigation-menu": "^1.2.4",
     "@radix-ui/react-slot": "^1.1.1",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,5 +7,6 @@
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --navy: #0C2C47;
+    --radius: 0.5rem;
   }
 }

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -1,0 +1,369 @@
+'use client'
+
+import React, { useState, useEffect, ChangeEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import Header from '@/components/header';
+import Footer from '@/components/footer';
+
+interface OrganisationWithIGHead {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  isInactive: boolean;
+  isInvisible: boolean;
+  igHead?: {
+    name: string;
+    telegramHandle?: string;
+  };
+  inviteLink?: string;
+  hasVerified?: boolean;
+}
+
+interface IGCategories {
+  [key: string]: string;
+}
+
+const DEFAULT_FILTERS: string[] = ['Sports', 'SocioCultural', 'Others'];
+
+// Utility function to make categories prettier
+const makeCategoriesPrettier = (categories: any): IGCategories => {
+  const prettierCategories: IGCategories = {};
+  Object.keys(categories).forEach(key => {
+    prettierCategories[key] = categories[key].replace(/([A-Z])/g, ' $1').trim();
+  });
+  return prettierCategories;
+};
+
+export default function StudentGroupsPage() {
+  const [allOrgs, setAllOrgs] = useState<OrganisationWithIGHead[]>([]);
+  const [igCardsToDisplay, setIgCardsToDisplay] = useState<OrganisationWithIGHead[]>([]);
+  const [allIGCategories, setAllIGCategories] = useState<IGCategories>({});
+  const [interestGroupFilters, setInterestGroupFilters] = useState<string[]>(DEFAULT_FILTERS);
+  const [interestGroupSearchString, setInterestGroupSearchString] = useState('');
+  const [isInactive, setIsInactive] = useState<boolean>(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  
+  // Pagination
+  const [page, setPage] = useState(1);
+  const pageSize = 9;
+
+  // Fetch data on component mount
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://api.nusc.club/';
+        
+        const [orgsResponse, categoriesResponse] = await Promise.all([
+          fetch(`${backendUrl}orgs`),
+          fetch(`${backendUrl}orgs/categories`)
+        ]);
+
+        if (!orgsResponse.ok || !categoriesResponse.ok) {
+          throw new Error('Failed to fetch data');
+        }
+
+        const orgsData = await orgsResponse.json();
+        const categoriesData = await categoriesResponse.json();
+        
+        setAllOrgs(orgsData);
+        setAllIGCategories(makeCategoriesPrettier(categoriesData));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+        console.error('Error fetching data:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  // Handle search input
+  const onInput = (ev: ChangeEvent<HTMLInputElement>) => {
+    const { value } = ev.target;
+    setInterestGroupSearchString(value.toLowerCase());
+  };
+
+  // Handle category filter changes
+  const handleCategoryChange = (category: string, checked: boolean) => {
+    if (checked) {
+      setInterestGroupFilters([...interestGroupFilters, category]);
+    } else {
+      setInterestGroupFilters(interestGroupFilters.filter((filter) => filter !== category));
+    }
+  };
+
+  // Handle inactive filter change
+  const handleInactiveChange = (checked: boolean) => {
+    setIsInactive(checked);
+  };
+
+  // Filter and search logic
+  useEffect(() => {
+    const visibleCards = allOrgs.filter((card) => !card.isInvisible);
+    const inactiveFilteredCards = visibleCards.filter((card) => !(card.isInactive && !isInactive));
+    let filteredCards = inactiveFilteredCards.filter((card) =>
+      interestGroupFilters.includes(card.category)
+    );
+    filteredCards = filteredCards.filter((ig) =>
+      ig.name.toLowerCase().includes(interestGroupSearchString)
+    );
+    setIgCardsToDisplay(filteredCards);
+    setPage(1);
+  }, [interestGroupFilters, interestGroupSearchString, allOrgs, isInactive]);
+
+  // Pagination logic
+  const paginateArray = (pageNumber: number) => {
+    return igCardsToDisplay.slice(
+      (pageNumber - 1) * pageSize,
+      (pageNumber - 1) * pageSize + pageSize
+    );
+  };
+  
+  const totalPages = Math.ceil(igCardsToDisplay.length / pageSize);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-white">
+        <Header />
+        <div className="flex items-center justify-center min-h-[calc(100vh-160px)]">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-[#FF7D4E] mx-auto mb-4"></div>
+            <p className="text-gray-600">Loading student groups...</p>
+          </div>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-white">
+        <Header />
+        <div className="flex items-center justify-center min-h-[calc(100vh-160px)]">
+          <div className="text-center">
+            <p className="text-red-600 mb-4">Error loading student groups: {error}</p>
+            <Button onClick={() => window.location.reload()} className="bg-[#FF7D4E] hover:bg-[#FF7D4E]/90">
+              Retry
+            </Button>
+          </div>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <div className="flex min-h-[calc(100vh-80px)]">
+        {/* Sidebar */}
+        <div className="w-72 bg-white px-8 py-8 border-r">
+          <div className="mb-6 bg-[#F5F5F5] p-4 rounded-md">
+            <h3 className="font-semibold text-gray-900 mb-3">Copy link to...</h3>
+            <Button className="bg-[#FF7D4E] hover:bg-[#FF7D4E]/90 text-white text-sm ml-3 p-6 rounded-md">
+              STUDENT GROUP<br></br>TELEGRAM CHAT
+            </Button>
+          </div>
+          
+          <div className="mb-6">
+            <h3 className="font-semibold text-gray-900 mb-3">SEARCH</h3>
+            <Input 
+              type="search" 
+              placeholder="Search groups..." 
+              className="w-full"
+              onChange={onInput}
+              value={interestGroupSearchString}
+            />
+          </div>
+          
+          <div className="mb-6">
+            <h3 className="font-semibold text-gray-900 mb-3">CATEGORIES</h3>
+            <div className="space-y-3">
+              {Object.keys(allIGCategories).map((category) => (
+                <div key={category} className="flex items-center space-x-2">
+                  <Checkbox 
+                    id={category}
+                    checked={interestGroupFilters.includes(category)}
+                    onCheckedChange={(checked) => handleCategoryChange(category, checked as boolean)}
+                  />
+                  <label htmlFor={category} className="text-sm text-gray-700">
+                    {allIGCategories[category].toUpperCase()}
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-3">OPTIONS</h3>
+            <div className="flex items-center space-x-2">
+              <Checkbox 
+                id="show-inactive"
+                checked={isInactive}
+                onCheckedChange={(checked) => handleInactiveChange(checked as boolean)}
+              />
+              <label htmlFor="show-inactive" className="text-sm text-gray-700">
+                SHOW INACTIVE GROUPS
+              </label>
+            </div>
+          </div>
+        </div>
+        
+        {/* Main Content */}
+        <div className="flex-1 bg-[#0C2C47] px-16 py-8">
+          <div className="mb-8">
+            <h1 className="text-4xl font-bold text-white mb-2">Student Groups</h1>
+            <p className="text-white/80">{igCardsToDisplay.length} RESULTS</p>
+          </div>
+          
+          {/* Groups Grid */}
+          {igCardsToDisplay.length === 0 ? (
+            <div className="text-center text-white/80 py-16">
+              <p className="text-xl mb-2">No student groups found</p>
+              <p>Try adjusting your search or filter criteria</p>
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+                {paginateArray(page).map((group) => (
+                  <div key={group.id} className="bg-white rounded-lg p-6 relative">
+                    {group.hasVerified && (
+                      <div className="absolute top-4 right-4 w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center">
+                        <span className="text-white text-sm font-bold">V</span>
+                      </div>
+                    )}
+                    
+                    {group.isInactive && (
+                      <div className="absolute top-2 left-2 bg-gray-500 text-white text-xs px-2 py-1 rounded">
+                        INACTIVE
+                      </div>
+                    )}
+                    
+                    <h3 className="text-xl font-bold text-gray-900 mb-3 text-center">{group.name}</h3>
+                    <p className="text-[#A1A1A1] text-sm mb-4 leading-relaxed line-clamp-6">
+                      {group.description || "No description available."}
+                    </p>
+                    
+                    {group.igHead && (
+                      <p className="text-xs text-gray-500 mb-4">
+                        Headed by {group.igHead.name}
+                        {group.igHead.telegramHandle && ` (@${group.igHead.telegramHandle})`}
+                      </p>
+                    )}
+                    
+                    <div className="flex gap-2">
+                      <Button 
+                        variant="outline" 
+                        size="sm" 
+                        className="bg-[#0C2C47] text-white hover:bg-[#0C2C47]/90 border-[#0C2C47] text-xs px-6 py-1"
+                      >
+                        IG HEAD
+                      </Button>
+                      {group.inviteLink ? (
+                        <Button 
+                          size="sm" 
+                          className="bg-[#FF7D4E] hover:bg-[#FF7D4E]/90 text-white text-xs px-4 py-1"
+                          onClick={() => window.open(group.inviteLink, '_blank')}
+                        >
+                          JOIN IG GROUP
+                        </Button>
+                      ) : (
+                        <Button 
+                          size="sm" 
+                          className="bg-gray-400 text-white text-xs px-3 py-1 cursor-not-allowed"
+                          disabled
+                        >
+                          NO GROUP LINK
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className="flex justify-center items-center space-x-2">
+                  <Button 
+                    variant="ghost" 
+                    size="sm" 
+                    className="text-white hover:text-white/80 hover:bg-white/10"
+                    onClick={() => setPage(1)}
+                    disabled={page === 1}
+                  >
+                    &lt;&lt;
+                  </Button>
+                  <Button 
+                    variant="ghost" 
+                    size="sm" 
+                    className="text-white hover:text-white/80 hover:bg-white/10"
+                    onClick={() => setPage(Math.max(1, page - 1))}
+                    disabled={page === 1}
+                  >
+                    &lt;
+                  </Button>
+                  
+                  {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                    let pageNumber;
+                    if (totalPages <= 5) {
+                      pageNumber = i + 1;
+                    } else if (page <= 3) {
+                      pageNumber = i + 1;
+                    } else if (page >= totalPages - 2) {
+                      pageNumber = totalPages - 4 + i;
+                    } else {
+                      pageNumber = page - 2 + i;
+                    }
+                    
+                    return (
+                      <Button
+                        key={pageNumber}
+                        size="sm"
+                        variant={page === pageNumber ? "default" : "ghost"}
+                        className={
+                          page === pageNumber
+                            ? "bg-white text-[#0C2C47] hover:bg-white/90 min-w-[32px]"
+                            : "text-white hover:text-white/80 hover:bg-white/10 min-w-[32px]"
+                        }
+                        onClick={() => setPage(pageNumber)}
+                      >
+                        {pageNumber}
+                      </Button>
+                    );
+                  })}
+                  
+                  <Button 
+                    variant="ghost" 
+                    size="sm" 
+                    className="text-white hover:text-white/80 hover:bg-white/10"
+                    onClick={() => setPage(Math.min(totalPages, page + 1))}
+                    disabled={page === totalPages}
+                  >
+                    &gt;
+                  </Button>
+                  <Button 
+                    variant="ghost" 
+                    size="sm" 
+                    className="text-white hover:text-white/80 hover:bg-white/10"
+                    onClick={() => setPage(totalPages)}
+                    disabled={page === totalPages}
+                  >
+                    &gt;&gt;
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -151,7 +151,7 @@ export default function Header() {
                 label="STUDENT LIFE" 
                 items={[
                   { label: "EVENTS", href: "/events" },
-                  { label: "STUDENT GROUPS", href: "/" },
+                  { label: "STUDENT GROUPS", href: "/groups" },
                   { label: "VENUE BOOKING", href: "/bookings" }
                 ]} 
               />

--- a/src/components/show-ig-modal.tsx
+++ b/src/components/show-ig-modal.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import React, { useState, useMemo } from 'react';
+import BaseModal from './base-modal';
+import { Button } from '@/components/ui/button';
+
+interface OrganisationWithIGHead {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  isInactive: boolean;
+  isInvisible: boolean;
+  userOrg: Array<{
+    isIGHead: boolean;
+    user: {
+      name: string;
+      telegramHandle?: string;
+    };
+  }>;
+  inviteLink?: string;
+  hasVerified?: boolean;
+}
+
+interface ShowIGModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  organisation: OrganisationWithIGHead | null;
+}
+
+export default function ShowIGModal({ isOpen, onClose, organisation }: ShowIGModalProps) {
+  const [selectedIGHead, setSelectedIGHead] = useState<string>('');
+  const [copySuccess, setCopySuccess] = useState<{ [key: string]: boolean }>({});
+
+  // Extract IG Heads from the organisation data
+  const igHeads = useMemo(() => {
+    return organisation ? organisation.userOrg
+      .filter(userOrg => userOrg.isIGHead)
+      .map(userOrg => ({
+        name: userOrg.user.name,
+        telegramHandle: userOrg.user.telegramHandle
+      })) : [];
+  }, [organisation]);
+
+  // Set default selected IG Head if not already set
+  React.useEffect(() => {
+    if (igHeads.length > 0 && !selectedIGHead) {
+      setSelectedIGHead(igHeads[0].name);
+    }
+  }, [igHeads, selectedIGHead]);
+
+  if (!organisation) return null;
+
+  const copyToClipboard = async (text: string, type: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopySuccess({ ...copySuccess, [type]: true });
+      setTimeout(() => {
+        setCopySuccess({ ...copySuccess, [type]: false });
+      }, 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  const getSelectedIGHeadTelegram = () => {
+    const selectedHead = igHeads.find(head => head.name === selectedIGHead);
+    return selectedHead?.telegramHandle || '';
+  };
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`${organisation.name} Details`}
+      cancelLabel="CLOSE"
+    >
+      <div className="space-y-4">
+        {/* Interest Group Name */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Interest Group Name
+          </label>
+          <div className="p-3 bg-gray-50 rounded-md border">
+            <p className="text-sm text-gray-900">{organisation.name}</p>
+          </div>
+        </div>
+
+        {/* Description */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Description
+          </label>
+          <div className="p-3 bg-gray-50 rounded-md border min-h-[80px]">
+            <p className="text-sm text-gray-900 leading-relaxed">
+              {organisation.description || "No description available."}
+            </p>
+          </div>
+        </div>
+
+        {/* IG Head Selection */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            IG Head
+          </label>
+          {igHeads.length > 1 ? (
+            <select
+              value={selectedIGHead}
+              onChange={(e) => setSelectedIGHead(e.target.value)}
+              className="w-full p-3 bg-white border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="">Select an IG Head</option>
+              {igHeads.map((head) => (
+                <option key={head.name} value={head.name}>
+                  {head.name}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <div className="p-3 bg-gray-50 rounded-md border">
+              <p className="text-sm text-gray-900">
+                {igHeads.length > 0 ? igHeads[0].name : "No IG Head assigned"}
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* IG Head's Telegram */}
+        {getSelectedIGHeadTelegram() && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              IG Head&apos;s Telegram
+            </label>
+            <div className="flex items-center gap-2">
+              <div className="flex-1 p-3 bg-gray-50 rounded-md border">
+                <p className="text-sm text-gray-900">{getSelectedIGHeadTelegram()}</p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => copyToClipboard(getSelectedIGHeadTelegram(), 'telegram')}
+                className="px-3 py-2 text-xs"
+              >
+                {copySuccess.telegram ? (
+                  <span className="text-green-600">Copied!</span>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                  </svg>
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Join IG Group Link */}
+        {organisation.inviteLink && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Group Link
+            </label>
+            <div className="flex items-center gap-2">
+              <div className="flex-1 p-3 bg-gray-50 rounded-md border">
+                <p className="text-sm text-gray-900 break-all">{organisation.inviteLink}</p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => copyToClipboard(organisation.inviteLink!, 'invite')}
+                className="px-3 py-2 text-xs"
+              >
+                {copySuccess.invite ? (
+                  <span className="text-green-600">Copied!</span>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                  </svg>
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Status Indicators */}
+        <div className="flex flex-wrap gap-2 pt-2">
+          {organisation.isInactive && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+              Inactive
+            </span>
+          )}
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+            {organisation.category}
+          </span>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -73,5 +73,8 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    require("tailwindcss-animate"),
+    require("@tailwindcss/line-clamp"),
+  ],
 } satisfies Config;


### PR DESCRIPTION
# Add Student Groups Webpage

## Description
This PR implements the Student Groups webpage based on the Figma design provided by the design team.

## Main Changes
- **New Student Groups Page**
  - Displays a list of student interest groups using data fetched from the existing legacy backend.
- **Modal View**
  - Clicking on an interest group opens a modal with expanded details.
- **Styling & Layout**
  - Layout adheres closely to the Figma spec for desktop view.

## Next Steps / To-Do
- Implement responsive layout and styles for **mobile view**.
- Display **Telegram handle of selected IG Heads** inside the modal view.
- Modifications to fit new backend params once deployed.

## Screenshots
<img width="1920" height="1120" alt="Screenshot 2025-07-12 at 9 02 18 PM" src="https://github.com/user-attachments/assets/d7456bfd-3607-4271-a703-8529198c6d13" />